### PR TITLE
Fix voice transcript sensitivity for natural speech patterns

### DIFF
--- a/code/ai_assessment_assistant/app/views/voice_assessment/show.html.erb
+++ b/code/ai_assessment_assistant/app/views/voice_assessment/show.html.erb
@@ -416,9 +416,9 @@
                 input_audio_transcription: { model: 'whisper-1' },
                 turn_detection: {
                   type: 'server_vad',
-                  threshold: 0.5,
+                  threshold: 0.6,
                   prefix_padding_ms: 300,
-                  silence_duration_ms: 500
+                  silence_duration_ms: 1500
                 },
                 temperature: 0.7
               }


### PR DESCRIPTION
## Problem
The voice assessment system was too sensitive to pauses in speech, causing it to break up sentences unnaturally. For example:
- Single sentences were split at brief pauses ("um...", thinking pauses)
- Background noise could trigger new transcript lines

## Solution
Adjusted the OpenAI Realtime API turn detection settings:

### 1. Increased silence duration
- **Before**: 500ms (0.5 seconds)
- **After**: 1500ms (1.5 seconds)
- **Result**: Allows for natural pauses without breaking sentences

### 2. Increased threshold sensitivity
- **Before**: 0.5
- **After**: 0.6
- **Result**: Less sensitive to background noise

## Impact
- More natural conversation flow
- Complete sentences captured as single transcript entries
- Reduced false triggers from ambient sounds
- Better handling of natural speech patterns like "um...", "you know", and thinking pauses

## Testing
Please test with:
1. Speaking with natural pauses and filler words
2. Having some background noise present
3. Taking brief pauses to think mid-sentence